### PR TITLE
Add comment command

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -125,6 +125,7 @@
 \newcommand{\ie}{\emph{i.e.,}}
 \newcommand{\eg}{\emph{e.g.,}}
 \newcommand{\etal}{\emph{et~al.}}
+\newcommand{\comment}[1]{}
 
 \usepackage{pifont}
 \newcommand{\Yes}{\ding{51}}
@@ -219,6 +220,11 @@ This is how you typeset descriptions:
 \item[Beach Boys] \lipsum[1]
 \item[The Ronettes] \lipsum[2]
 \end{description}
+
+\begin{comment}
+Example of a really, really long
+multi-line comment
+\end{comment}
 
 Enumerated lists:
 


### PR DESCRIPTION
Allows for nice mult-line comments, e.g.

```
\begin{comment}
Example of a really, really long
multi-line comment
\end{comment}
```