### PR TITLE
Don't use interactive mode by default and more `make clean`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,24 @@
+# The `-interaction=nonstopmode -halt-on-error` arguments make LaTeX terminate on the first error.
+# This makes it a bit nicer to use with IDE integration and is closer to the behavior of
+# Overleaf which most people are familiar with.
+#
+# You can remove these arguments, if you want the default interactive behavior of LaTeX.
+
 main:
-	latexmk -pdf -synctex=1 main
+	latexmk -pdf -synctex=1 -interaction=nonstopmode -halt-on-error  main
 
 bib:
 	bibtex main
 
 cycle:
 	# Note: better to use latexmk which figures out exactly what to run and how many times
-	pdflatex --synctex=1 main
+	pdflatex --synctex=1 -interaction=nonstopmode -halt-on-error main
 	bibtex main
-	pdflatex --synctex=1 main
-	pdflatex --synctex=1 main
+	pdflatex --synctex=1 -interaction=nonstopmode -halt-on-error main
+	pdflatex --synctex=1 -interaction=nonstopmode -halt-on-error main
 
 clean:
-	rm -f *.aux *.lof *.log *.lot *.pdf *.synctex.gz *.toc *.fdb_latexmk
+	rm -f *.aux *.lof *.log *.lot *.pdf *.synctex.gz *.toc *.fdb_latexmk *.bbl *.blg *.out *.bcf
 
 diff.tex:
 	@echo "This command assumes you have checked out the previous version"
@@ -23,5 +29,5 @@ diff.tex:
 	latexdiff prev.tex main.tex > diff.tex
 
 diff: diff.tex
-	pdflatex --synctex=1 diff.tex
+	pdflatex --synctex=1 -interaction=nonstopmode -halt-on-error diff.tex
 


### PR DESCRIPTION
This is probably a question of taste. The interactive mode of LaTeX always confused me. I prefer looking at the files directly and fix the issues there.

Having this as the default makes it a bit easier to use with IDEs. Now I can run the build command on every safe and just see the output without it trying to *talk* to me.